### PR TITLE
API-1289: Create new Dockerfile to install google sdk with helm

### DIFF
--- a/.github/workflows/build-google-sdk-505.yml
+++ b/.github/workflows/build-google-sdk-505.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'google-sdk/467.0.0-alpine/*'
+      - 'google-sdk/505.0.0-alpine/*'
 
 jobs:
-  build-push-google-sdk-467:
+  build-push-google-sdk-505:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,12 +22,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push google-sdk 467.0.0 alpine
+      - name: Build and push google-sdk 505.0.0 alpine
         uses: docker/build-push-action@v5
         with:
-          file: ./google-sdk/467.0.0-alpine/Dockerfile
-          context: ./google-sdk/467.0.0-alpine/
+          file: ./google-sdk/505.0.0-alpine/Dockerfile
+          context: ./google-sdk/505.0.0-alpine/
           push: true
           tags: |
             imageszh/google-sdk:latest
-            imageszh/google-sdk:467.0.0
+            imageszh/google-sdk:505.0.0

--- a/google-sdk/505.0.0-alpine/Dockerfile
+++ b/google-sdk/505.0.0-alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM google/cloud-sdk:505.0.0-alpine
+
+RUN apk add envsubst kubectl openssl
+
+RUN gcloud --quiet components install gke-gcloud-auth-plugin
+
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash


### PR DESCRIPTION
Crear imagen de docker
```
docker rbuild -t gcloud-sdk ./google-sdk/505.0.0-alpine
```
Ejecutar sh en la imagen y comprobar que se han instalado correctamente el sdk y helm
```
docker run -it gcloud-sdk sh
```
```
helm version
```
```
gcloud --version
```